### PR TITLE
Add team creation/association during project creation back-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 todo.md
-temp/
+
 # Created by https://www.gitignore.io/api/node,sass,macos,laravel,windows
 # Edit at https://www.gitignore.io/?templates=node,sass,macos,laravel,windows
 
@@ -9,6 +9,7 @@ node_modules/
 npm-debug.log
 yarn-error.log
 
+temp/
 
 # Laravel 4 specific
 bootstrap/compiled.php

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -201,6 +201,7 @@ class CourseController extends Controller
 		if (!$course->exists) {
 			abort(500);
 		}
+
 		return $course;
 	}
 

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -82,11 +82,11 @@ class ProjectController extends Controller {
 		else {
 			// Associate the team to the project
 			$team_id = $attributes['existingTeam'];
-			abort_if(
-				!$this->validateTeam($team_id, $attributes['course']),
-				400,
-				'Some team members do not belong to the course you\'re trying to create this project in.'
-			);
+			if(!$this->validateTeam($team_id, $attributes['course'])) {
+				return redirect('projects/create')->withErrors([
+					'teamMembership' => 'Some team members do not belong to the course you\'re trying to create this project in.'
+				])->withInput();
+			}
 			$attributes['team_id'] = $team_id;
 		}
 

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -112,8 +112,8 @@ class ProjectController extends Controller {
 			if(!$member->enrolledIn()->where('course_id', $course_id)->exists()) {
 				return false;
 			}
-
 		}
+
 		return true;
 	}
 

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -87,6 +87,7 @@ class ProjectController extends Controller {
 					'teamMembership' => 'Some team members do not belong to the course you\'re trying to create this project in.'
 				])->withInput();
 			}
+
 			$attributes['team_id'] = $team_id;
 		}
 
@@ -106,10 +107,12 @@ class ProjectController extends Controller {
 		if(!$team->exists()) {
 			return false;
 		}
+
 		foreach($team->members()->get() as $member) {
 			if(!$member->enrolledIn()->where('course_id', $course_id)->exists()) {
 				return false;
 			}
+
 		}
 		return true;
 	}

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -68,6 +68,7 @@ class ProjectController extends Controller {
 				'bothTeams' => 'You can either create a new team, OR associate to an existing team, but not both.'
 			])->withInput();
 		}
+
 		if(empty($attributes['teamId'])) {
 			// Save a new team
 			$team = new \App\Team();
@@ -81,7 +82,6 @@ class ProjectController extends Controller {
 			// Associate the team to the project
 			$attributes['team_id'] = $attributes['teamId'];
 		}
-
 
 		$project = $this->saveRecord($attributes);
 

--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -55,7 +55,7 @@ class TeamController extends Controller
 
 		$team->members()->attach($team->leader_id);
 
-		// redirect to teams/{id}
+		// redirect to teams/{id} // NOSONAR
 		return redirect()->route('teams.show', [$team]);
 	}
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -23,7 +23,7 @@ class UserController extends Controller {
 	 * @return \Illuminate\View
 	 */
 	public function show(int $id) {
-		$user = User::find($id);
+		$user = User::findOrFail($id);
 		return view('user.details', compact('user'));
 	}
 
@@ -108,10 +108,9 @@ class UserController extends Controller {
 
 		// prevent insertion of duplicates
 		$isDuplicatedCourse = $user->enrolledIn()->where('course_id', $course->id)->exists();
-
 		abort_if($isDuplicatedCourse, 400, 'Duplicated course');
 
-		$result = $user->enrolledIn()->attach($course);
+		$user->enrolledIn()->attach($course);
 
 		return $course;
 	}

--- a/app/Project.php
+++ b/app/Project.php
@@ -31,4 +31,8 @@ class Project extends Model
 	public function course() {
 		return $this->belongsTo('App\Course');
 	}
+	// Get the team the project belongs to
+	public function team() {
+		return $this->belongsTo('App\Team');
+	}
 }

--- a/app/Team.php
+++ b/app/Team.php
@@ -20,4 +20,7 @@ class Team extends Model
 	public function members() {
 		return $this->belongsToMany('App\User', 'team_user', 'team_id', 'user_id');
 	}
+	public function projects() {
+		return $this->hasMany('App\Project');
+	}
 }

--- a/database/migrations/2019_03_24_224218_add_team_id_to_projects_table.php
+++ b/database/migrations/2019_03_24_224218_add_team_id_to_projects_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddTeamIdToProjectsTable extends Migration {
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		Schema::table('projects', function (Blueprint $table) {
+			$table->unsignedInteger('team_id');
+			$table->foreign('team_id')->references('id')->on('teams')->onDelete('cascade');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down() {
+		Schema::table('projects', function (Blueprint $table) {
+			$table->dropColumn('team_id');
+		});
+	}
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -47,6 +47,9 @@
 	<rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword">
 		<severity>0</severity>
 	</rule>
+	<rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace">
+		<severity>0</severity>
+	</rule>
 
 	<rule ref="Squiz.ControlStructures.ElseIfDeclaration"/>
 	<rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>


### PR DESCRIPTION
This PR:

- Adds the `team_id` field necessary to the `projects` DB table to support the association between the Teams and Projects objects
- Adds the corresponding associations to the models
- Adds back-end validation to add XOR associate a team in the front-end and redirects with appropriate error message otherwise
- Creates a new team before project creation and associates it OR associates an existing team depending on the user's choice

## Missing

- [x] Validation of associated team members (that they are within the same course)

## Run this PR

This PR features a **migration**. Run `php artisan migrate` (or `migrate:fresh`) on your terminal to run this patch.

## Related

Partially fixes #102 (missing front-end). Blocked by #100.

