### PR TITLE
Add image resize module

### DIFF
--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -8,6 +8,9 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
+use Intervention\Image\ImageManagerStatic as Image;
+use Illuminate\Support\Facades\Storage;
+
 
 class TeamController extends Controller
 {
@@ -49,6 +52,9 @@ class TeamController extends Controller
 		]);
 
 		$team = $this->createTeam($attributes, $request->file('teamImage'));
+
+		$this->save_resized_image($request);
+
 		if (!$team->exists) {
 			abort(500);
 		}
@@ -56,6 +62,18 @@ class TeamController extends Controller
 		$team->members()->attach($team->leader_id);
 
 		return view('teams.details', compact('team'));
+	}
+
+	private function save_resized_image($req) {
+		if($req->hasFile('teamImage')) {
+			$ext = $req->teamImage->extension();
+			$path = $req->teamImage->store('teams/avatars');
+			$nameindex = strrpos($path, ".");
+			$name = substr($path, 0, $nameindex);
+			$resized_name = $name."_400x400.".$ext;
+			$resized_img = Image::make($req->teamImage)->fit(400);
+			Storage::put($resized_name, $resized_img->encode($ext));
+		}
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
 		"cache/filesystem-adapter": "^1.0",
 		"fideloper/proxy": "^4.0",
 		"google/apiclient": "^2.2",
+		"intervention/image": "^2.4",
 		"laravel/framework": "5.7.*",
 		"laravel/tinker": "^1.0"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "18f619663088248c62529d77282ba176",
+    "content-hash": "728f89cb9067de06d27acdd9be5ed4fd",
     "packages": [
         {
             "name": "cache/adapter-common",
@@ -921,6 +921,76 @@
                 "url"
             ],
             "time": "2018-12-04T20:46:45+00:00"
+        },
+        {
+            "name": "intervention/image",
+            "version": "2.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image.git",
+                "reference": "e82d274f786e3d4b866a59b173f42e716f0783eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/e82d274f786e3d4b866a59b173f42e716f0783eb",
+                "reference": "e82d274f786e3d4b866a59b173f42e716f0783eb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "guzzlehttp/psr7": "~1.1",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.2",
+                "phpunit/phpunit": "^4.8 || ^5.7"
+            },
+            "suggest": {
+                "ext-gd": "to use GD library based image processing.",
+                "ext-imagick": "to use Imagick based image processing.",
+                "intervention/imagecache": "Caching extension for the Intervention Image library"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Intervention\\Image\\ImageServiceProvider"
+                    ],
+                    "aliases": {
+                        "Image": "Intervention\\Image\\Facades\\Image"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\": "src/Intervention/Image"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@olivervogel.com",
+                    "homepage": "http://olivervogel.com/"
+                }
+            ],
+            "description": "Image handling and manipulation library with support for Laravel integration",
+            "homepage": "http://image.intervention.io/",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "laravel",
+                "thumbnail",
+                "watermark"
+            ],
+            "time": "2018-05-29T14:19:03+00:00"
         },
         {
             "name": "jakub-onderka/php-console-color",

--- a/config/app.php
+++ b/config/app.php
@@ -174,7 +174,7 @@ return [
 		// App\Providers\BroadcastServiceProvider::class,
 		App\Providers\EventServiceProvider::class,
 		App\Providers\RouteServiceProvider::class,
-
+		Intervention\Image\ImageServiceProvider::class
 	],
 
 	/*
@@ -223,7 +223,7 @@ return [
 		'URL' => Illuminate\Support\Facades\URL::class,
 		'Validator' => Illuminate\Support\Facades\Validator::class,
 		'View' => Illuminate\Support\Facades\View::class,
-
+		'Image' => Intervention\Image\Facades\Image::class
 	],
 
 ];

--- a/config/image.php
+++ b/config/image.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Image Driver
+    |--------------------------------------------------------------------------
+    |
+    | Intervention Image supports "GD Library" and "Imagick" to process images
+    | internally. You may choose one of them according to your PHP
+    | configuration. By default PHP's "GD Library" implementation is used.
+    |
+    | Supported: "gd", "imagick"
+    |
+    */
+
+    'driver' => 'gd'
+
+];


### PR DESCRIPTION
This PR: 

- Adds the required vendor packages for image resizing
- Adds resizing for an image upload (during team creation)
- Adds the required configuration

## Run this PR

This PR includes a new vendor package. You **must** run `composer install` in your terminal after merging this patch.

### Related

This PR fixes #13 