### PR TITLE
S33 fix: routing and styling

### DIFF
--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -55,7 +55,8 @@ class TeamController extends Controller
 
 		$team->members()->attach($team->leader_id);
 
-		return view('teams.details', compact('team'));
+		// redirect to teams/{id}
+		return redirect()->route('teams.show', [$team]);
 	}
 
 	/**

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -382,6 +382,7 @@ $color-white: #fff;
 			height: 10vmax;
 			object-fit: cover;
 			object-position: center center;
+			border-radius: 15px;
 		}
 	}
 

--- a/resources/views/teams/details.blade.php
+++ b/resources/views/teams/details.blade.php
@@ -7,7 +7,9 @@
 	<h1>{{ $team->name }}</h1>
 	<div class="team-info">
 		<div class="image-container">
-			<img id="avatar" src="<?= $team->img_url ?>" alt="Team avatar" class="ui small image"/>
+			<div class="image-uploader preview-container">
+				<img id="preview" src="<?= $team->img_url ?>" alt="Team image" class="ui small image preview"/>
+			</div>
 		</div>
 		<div class="team-people">
 			<h2>People</h2>
@@ -26,6 +28,12 @@
 	<div class="team-projects">
 		<h2>Projects</h2>
 		<!-- TODO: add project cards -->
+		<div class="ui message">
+		<div class="header">
+			No projects available
+		</div>
+		<p>Looks like this team has no projects at the moment.</p>
+		</div>
 	</div>
 </div>
 @endsection

--- a/resources/views/teams/details.blade.php
+++ b/resources/views/teams/details.blade.php
@@ -12,12 +12,12 @@
 			</div>
 		</div>
 		<div class="team-people">
-			<h2>People</h2>
+			<p><strong>People</strong></p>
 			<div class="team-members">
 				@if(isset($team->members))
 					@foreach($team->members as $member)
 						<!-- TODO: add route to user profile -->
-						<a href="https://www.google.com">
+						<a href="#">
 							<img class="ui avatar image" src="<?= $member->picture_url ?>"/>
 						</a>
 					@endforeach
@@ -26,7 +26,7 @@
 		</div>
 	</div>
 	<div class="team-projects">
-		<h2>Projects</h2>
+		<p><strong>Projects</strong></p>
 		<!-- TODO: add project cards -->
 		<div class="ui message">
 		<div class="header">


### PR DESCRIPTION
# Changes 
- On successful team creation, app redirects to details view for that team
- For the current workflow (standalone), no projects are associated so we display a message specifying this. 
- Fixed styles for consistency with other details views
- Rounded team image border corners
- Responsiveness testing is done

# Related
- #91 