### PR TITLE
Enhancements in create project view

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -237,6 +237,10 @@ $color-white: #fff;
 			width: 100%;
 		}
 	}
+
+	.ui.form .fields {
+		margin-bottom: 14px;
+	}
 }
 
 .progress {
@@ -391,4 +395,8 @@ $color-white: #fff;
 
 .detail-container {
 	margin-top: 25px;
+}
+
+.two-column-divider {
+	margin: 0 auto;
 }

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -362,18 +362,13 @@ $color-white: #fff;
 	}
 }
 
-.upload-image-button {
-	margin-top: 2em;
-	margin-bottom: 2em;
-}
-
 .image-container {
 	display: inline-block;
 	align-content: center;
 	.preview-container {
 		margin-bottom: 1vh;
 
-		.ui.small.image.preview {
+		.ui.image.preview {
 			width: 10vmax;
 			height: 10vmax;
 			object-fit: cover;

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -368,7 +368,7 @@ $color-white: #fff;
 	.preview-container {
 		margin-bottom: 1vh;
 
-		.ui.image.preview {
+		.ui.small.image.preview {
 			width: 10vmax;
 			height: 10vmax;
 			object-fit: cover;

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -29,13 +29,13 @@
 		<!-- Project name -->
 		<div class="field {{ $errors->has('projectName') ? 'error': '' }}">
 			<label for="projectName">Project name</label>
-			<input type="text" id="projectName"" name="projectName" placeholder="e.g. Best Project" value="{{ old('projectName') }}">
+			<input type="text" id="projectName"" name="projectName" placeholder="e.g. Best project" value="{{ old('projectName') }}">
 		</div>
 		<!-- Associated course -->
 		<div class="field {{ $errors->has('courses') ? 'error': '' }}">
 			<label for="course">Associated course</label>
 			<select name="course" id="course" class="ui search dropdown" value="{{ old('course') }}">
-				<option value="">e.g. Web development class</option>
+				<option value="">e.g. Web Development</option>
 				@if(isset($courses))
 					@foreach($courses->all() as $course)
 						<option value="{{ $course->id }}" {{ (old('course') == $course->id ? 'selected' : '') }}>{{ $course->name }}</option>
@@ -62,7 +62,7 @@
 			<div class="seven wide field {{ $errors->has('newTeam') || $errors->has('bothTeams') ? 'error': '' }}">
 				<div class="field associatedTeam">
 					<label for="newTeam">Create a new team</label>
-					<input id="newTeam" type="text" name="newTeam" placeholder="Create a new team" value="{{ old('newTeam')}}" onchange="createNewTeam()">
+					<input id="newTeam" type="text" name="newTeam" placeholder="e.g. New team" value="{{ old('newTeam')}}" onchange="createNewTeam()">
 				</div>
 			</div>
 		</div>

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -19,7 +19,7 @@
 			<label for="projectImage">Project image</label>
 			<div class="image-container">
 				<div class="imgUploader preview-container">
-					<img src="https://dummyimage.com/400x400/3498db/ffffff.png&text=B" alt="Project image" class="ui small image preview" id="projectImagePreview"/>
+					<img src="" alt="Project image" class="ui small image preview" id="projectImagePreview"/>
 				</div>
 				<button class="imgUploader ui button primary" type="button">Upload image</button>
 			</div>
@@ -133,6 +133,9 @@
 		$("#projectImage").click();
 	});
 
+	/* hide empty image */
+	$("#projectImagePreview").hide();
+
 	function fillDummy() {
 		$('input[name=projectName]').val('Some project title');
 		$("select[name=course]").val('1');
@@ -162,6 +165,7 @@
 		// update preview when completed successfully
 		reader.addEventListener("load", function () {
 			$("#projectImagePreview").attr("src", reader.result);
+			$("#projectImagePreview").show();
 		});
 		reader.readAsDataURL(file);
 	}

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -19,7 +19,7 @@
 			<label for="projectImage">Project image</label>
 			<div class="image-container">
 				<div class="imgUploader preview-container">
-					<img src="https://lorempixel.com/400/400" alt="Project image" class="ui small image preview" id="projectImagePreview"/>
+					<img src="https://dummyimage.com/400x400/3498db/ffffff.png&text=B" alt="Project image" class="ui small image preview" id="projectImagePreview"/>
 				</div>
 				<button class="imgUploader ui button primary" type="button">Upload image</button>
 			</div>

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -140,11 +140,6 @@
 		$("#projectImage").click();
 	});
 
-	function validateImage(file) {
-		const maxImageSize = 1*1024*1024; // 1MiB
-		return (file.type == "image/png" || file.type == "image/jpg") && file.size <= maxImageSize;
-	}
-
 	function fillDummy() {
 		$('input[name=projectName]').val('Some project title');
 		$("select[name=courses]").val('1');
@@ -160,13 +155,19 @@
 	}
 
 	function updateImage(imageInput) {
-		let reader = new FileReader();
-		let file = imageInput.files[0];
-		if(!file || !validateImage(file)) {
+		const reader = new FileReader();
+
+		const file = imageInput.files[0];
+		const maxImageSize = 1024 * 1024 * 1; // 1MiB
+
+		// validate file
+		if (!file || !isValidImage(file, maxImageSize)) {
+			alert("Please upload a .png or .jpeg file. Maximum size: 1MiB.");
 			return false;
 		}
-		reader.addEventListener("load", function() {
-			// Update the img
+
+		// update preview when completed successfully
+		reader.addEventListener("load", function () {
 			$("#projectImagePreview").attr("src", reader.result);
 		});
 		reader.readAsDataURL(file);
@@ -226,7 +227,6 @@
 			},
 			newTeam: {
 				identifier: 'newTeam',
-				optional: false,
 				rules: [{
 					type: 'maxLength[30]',
 					prompt: 'Team name cannot be longer than 30 characters.'

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -46,13 +46,11 @@
 		<!-- Associated team -->
 		<div class="ui placeholder segment">
 			<div class="ui two column very relaxed stackable grid">
-				<div class="column">
+				<div class="column responsive-segment">
 					<div class="field associatedTeam">
 						<label for="existingTeam">Choose an existing team</label>
 						<select id="existingTeam" name="existingTeam" class="ui search dropdown team {{ $errors->has('existingTeam') || $errors->has('bothTeams') ? 'error': '' }}" value="{{ old('existingTeam') }}" onchange="selectTeam()">
-							<option value="">Associate an existing team</option>
-							<option value="1">Team 1</option>
-							<option value="2">Team 2</option>
+							<option value="">My teams</option>
 							@if(isset($teams))
 								@foreach($teams->all() as $team)
 									<option value="{{ $team->id }}">{{ $team->name }}</option>
@@ -61,7 +59,10 @@
 						</select>
 					</div>
 				</div>
-				<div class="column">
+				<div class="ui horizontal divider">
+					Or
+				</div>
+				<div class="column responsive-segment">
 					<div class="field associatedTeam">
 						<label for="newTeam">Create a new team</label>
 						<input id="newTeam" type="text" name="newTeam" placeholder="Create a new team" value="{{ old('newTeam')}}" onchange="createNewTeam()">
@@ -171,6 +172,7 @@
 		reader.readAsDataURL(file);
 	}
 
+	/* Team association */
 	function createNewTeam() {
 		$(".associatedTeam").removeClass("error");
 		$("#existingTeam").dropdown("clear");
@@ -181,13 +183,32 @@
 		$("#newTeam").val("");
 	}
 
+	/* Responsiveness not handled by Semantic */
+	function setResponsiveProperties(mobile) {
+		$(".ui.divider").hide();
+		if (mobile.matches) { // If media query matches
+			$(".ui.horizontal.divider").show();
+			$(".responsive-segment").addClass("row").removeClass("column");
+
+		}
+		else {
+			$(".ui.vertical.divider").show();
+			$(".responsive-segment").addClass("column").removeClass("row");
+		}
+	}
+
+	let mobile = window.matchMedia("(max-width: 767px)");
+	setResponsiveProperties(mobile);
+	mobile.addListener(setResponsiveProperties);
+
+	/* Semantic dropdown set up  */
 	$('.ui.dropdown').dropdown({ clearable: true });
 
+	/* Form validation */
 	$.fn.form.settings.rules.associatedTeam = function() {
 		return ($("#newTeam").val() != "" || $("#existingTeam").val() != "");
 	};
 
-	/* Form validation */
 	$('.ui.form').form({
 		fields: {
 			projectName: {

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -93,7 +93,7 @@
 		<!-- Milestone -->
 		<div class="field {{ $errors->has('milestone') ? 'error': '' }}">
 			<label for="milestone">Public milestone</label>
-			<input type="text" id="milestone" value="{{ old('milestone') }}" placeholder="e.g. Design">
+			<input type="text" name="milestone" id="milestone" value="{{ old('milestone') }}" placeholder="e.g. Design">
 		</div>
 		<!-- Short description -->
 		<div class="field {{ $errors->has('shortDescription') ? 'error': '' }}">

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -192,10 +192,10 @@
 			},
 			newTeam: {
 				identifier: 'newTeam',
-				optional: true
+				optional: true,
 				rules: [{
 					type: 'maxLength[30]',
-				}],
+				}]
 			},
 			courses: {
 				identifier: 'courses',
@@ -240,13 +240,9 @@
 				identifier: 'videoPitch',
 				rules:[
 					{
-						type: 'empty',
-						prompt: 'Please enter a link to pitch video.'
-					},
-					{
 						type: 'regExp',
 						value: '/^((http(s)?:\\/\\/)?)(www\\.)?((youtube\\.com\\/)|(youtu.be\\/))[\\S]+$/',
-						prompt: 'Please enter a valid youtube url.'
+						prompt: 'Pitch video must be a valid YouTube URL.'
 					}
 				]
 			}

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -47,7 +47,7 @@
 		<div class="ui placeholder segment">
 			<div class="ui two column very relaxed stackable grid">
 				<div class="column">
-					<div class="field">
+					<div class="field associatedTeam">
 						<label for="existingTeam">Choose an existing team</label>
 						<select id="existingTeam" name="existingTeam" class="ui search dropdown team {{ $errors->has('existingTeam') || $errors->has('bothTeams') ? 'error': '' }}" value="{{ old('existingTeam') }}" onchange="selectTeam()">
 							<option value="">Associate an existing team</option>
@@ -62,7 +62,7 @@
 					</div>
 				</div>
 				<div class="column">
-					<div class="field">
+					<div class="field associatedTeam">
 						<label for="newTeam">Create a new team</label>
 						<input id="newTeam" type="text" name="newTeam" placeholder="Create a new team" value="{{ old('newTeam')}}" onchange="createNewTeam()">
 					</div>
@@ -172,16 +172,22 @@
 	}
 
 	function createNewTeam() {
-		$("#existingTeam").dropdown('clear');
+		$(".associatedTeam").removeClass("error");
+		$("#existingTeam").dropdown("clear");
 	}
 
 	function selectTeam() {
+		$(".associatedTeam").removeClass("error");
 		$("#newTeam").val("");
 	}
 
 	$('.ui.dropdown').dropdown({ clearable: true });
 
-	/* Register button validation */
+	$.fn.form.settings.rules.associatedTeam = function() {
+		return ($("#newTeam").val() != "" || $("#existingTeam").val() != "");
+	};
+
+	/* Form validation */
 	$('.ui.form').form({
 		fields: {
 			projectName: {
@@ -190,11 +196,23 @@
 					type: 'empty'
 				}]
 			},
+			existingTeam: {
+				identifier: 'existingTeam',
+				rules: [{
+					type: 'associatedTeam',
+					prompt: 'Project must be associated with a team.'
+				}]
+			},
 			newTeam: {
 				identifier: 'newTeam',
-				optional: true,
+				optional: false,
 				rules: [{
 					type: 'maxLength[30]',
+					prompt: 'Team name cannot be longer than 30 characters.'
+				},
+				{
+					type: 'associatedTeam',
+					prompt: ''
 				}]
 			},
 			courses: {

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -32,7 +32,7 @@
 			<input type="text" id="projectName"" name="projectName" placeholder="e.g. Best project" value="{{ old('projectName') }}">
 		</div>
 		<!-- Associated course -->
-		<div class="field {{ $errors->has('courses') ? 'error': '' }}">
+		<div class="field {{ $errors->has('course') ? 'error': '' }}">
 			<label for="course">Associated course</label>
 			<select name="course" id="course" class="ui search dropdown" value="{{ old('course') }}">
 				<option value="">e.g. Web Development</option>
@@ -135,7 +135,7 @@
 
 	function fillDummy() {
 		$('input[name=projectName]').val('Some project title');
-		$("select[name=courses]").val('1');
+		$("select[name=course]").val('1');
 		$('input[name=newTeam]').val('Some team name');
 		let labels = $("#labels option").slice(1,4).toArray().map(t => t.value);
 		$('#labels').dropdown('set selected', labels);
@@ -214,8 +214,8 @@
 					}
 				}]
 			},
-			courses: {
-				identifier: 'courses',
+			course: {
+				identifier: 'course',
 				rules: [{
 					type: 'minCount[1]'
 				}]

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -19,7 +19,7 @@
 			<label for="projectImage">Project image</label>
 			<div class="image-container">
 				<div class="imgUploader preview-container">
-					<img src="https://lorempixel.com/400/400" alt="Project image" class="ui medium image preview" id="projectImagePreview"/>
+					<img src="https://lorempixel.com/400/400" alt="Project image" class="ui small image preview" id="projectImagePreview"/>
 				</div>
 				<button class="imgUploader ui button primary" type="button">Upload image</button>
 			</div>
@@ -290,7 +290,6 @@
 			}
 		},
 		onFailure:function() {
-			console.log('failed registration');
 			return false;
 		},
 		onSuccess:function() {

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -212,7 +212,10 @@
 				},
 				{
 					type: 'associatedTeam',
-					prompt: ''
+					prompt: function(){
+						// we only show team-association prompt once
+						return '';
+					}
 				}]
 			},
 			courses: {

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -34,11 +34,11 @@
 		<!-- Associated course -->
 		<div class="field {{ $errors->has('course') ? 'error': '' }}">
 			<label for="course">Associated course</label>
-			<select name="course" id="course" class="ui search dropdown" value="{{ old('course') }}">
+			<select name="course" id="course" class="ui search dropdown">
 				<option value="">e.g. Web Development</option>
 				@if(isset($courses))
 					@foreach($courses->all() as $course)
-						<option value="{{ $course->id }}" {{ (old('course') == $course->id ? 'selected' : '') }}>{{ $course->name }}</option>
+						<option value="{{ $course->id }}">{{ $course->name }}</option>
 					@endforeach
 				@endif
 			</select>
@@ -47,7 +47,7 @@
 		<div class="fields">
 			<div class="seven wide field {{ $errors->has('existingTeam') || $errors->has('bothTeams') ? 'error': '' }}">
 				<label for="existingTeam">Choose an existing team</label>
-				<select id="existingTeam" name="existingTeam" class="ui search dropdown team" value="{{ old('existingTeam') }}" onchange="selectTeam()">
+				<select id="existingTeam" name="existingTeam" class="ui search dropdown team" onchange="selectTeam()">
 					<option value="">My teams</option>
 					@if(isset($teams))
 						@foreach($teams->all() as $team)
@@ -133,7 +133,7 @@
 		$("#projectImage").click();
 	});
 
-	/* hide empty image */
+	/* Hide empty image */
 	$("#projectImagePreview").hide();
 
 	function fillDummy() {
@@ -275,6 +275,8 @@
 		}
 	});
 	// TODO: Associated Team Validation
+
+	/* Select old values in <selects> */
 	@if(old('labels') !== null)
 		let labels = '{!! json_encode(old("labels")) !!}';
 		labels = JSON.parse(labels);
@@ -285,6 +287,18 @@
 		let skillsets = '{!! json_encode(old("skillsets")) !!}';
 		skillsets = JSON.parse(skillsets);
 		$('#skillsets').dropdown('set selected', skillsets);
+	@endif
+
+	@if(old('course') !== null)
+		let course = '{!! json_encode(old("course")) !!}';
+		course = JSON.parse(course);
+		$('#course').dropdown('set selected', course);
+	@endif
+
+	@if(old('existingTeam') !== null)
+		let existingTeam = '{!! json_encode(old("existingTeam")) !!}';
+		existingTeam = JSON.parse(existingTeam);
+		$('#existingTeam').dropdown('set selected', existingTeam);
 	@endif
 </script>
 @endsection

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -12,15 +12,6 @@
 </style>
 <div class="padded content">
 	<h1>Create new project</h1>
-	@if($errors->any())
-		<div class="ui error message">
-			<ul>
-				@foreach ($errors->all() as $error)
-					<li>{{ $error }}</li>
-				@endforeach
-			</ul>
-		</div>
-	@endif
 	<form class="ui form {{ $errors->any() ? 'error': '' }}" method="post" enctype="multipart/form-data" action="/projects">
 		@csrf
 		<!-- Project image -->
@@ -32,13 +23,13 @@
 				</div>
 				<button class="imgUploader ui button primary" type="button">Upload image</button>
 			</div>
-			<input id="imgInput" name="projectImage" type="file" style="display:none" accept="image/x-png,image/jpeg,image/png" onchange="updateImage(this)">
+			<input id="projectImage" name="projectImage" type="file" style="display:none" accept="image/x-png,image/jpeg,image/png" onchange="updateImage(this)">
 		</div>
 		<button class="ui button primary" onclick="fillDummy()" type="button">Fill with dummy data </button>
 		<!-- Project name -->
 		<div class="field {{ $errors->has('projectName') ? 'error': '' }}">
 			<label for="projectName">Project name</label>
-			<input type="text" name="projectName" placeholder="e.g. Best Project" value="{{ old('projectName') }}">
+			<input type="text" id="projectName"" name="projectName" placeholder="e.g. Best Project" value="{{ old('projectName') }}">
 		</div>
 		<!-- Associated course -->
 		<div class="field {{ $errors->has('courses') ? 'error': '' }}">
@@ -72,8 +63,8 @@
 				</div>
 				<div class="column">
 					<div class="field">
-						<label for="createTeam">Create a new team</label>
-						<input id="newTeam" type="text" name="createTeam" placeholder="Create a new team" value="{{ old('createTeam')}}" onchange="createNewTeam()">
+						<label for="newTeam">Create a new team</label>
+						<input id="newTeam" type="text" name="newTeam" placeholder="Create a new team" value="{{ old('newTeam')}}" onchange="createNewTeam()">
 					</div>
 				</div>
 			</div>
@@ -83,7 +74,7 @@
 		</div>
 		<!-- Labels -->
 		<div class="field {{ $errors->has('label') ? 'error': '' }}">
-			<label for="label">Labels</label>
+			<label for="labels">Labels</label>
 			<select name="labels[]" id="labels" multiple class="ui search dropdown">
 				<option value="">e.g. Finance</option>
 				@if(isset($labels))
@@ -113,22 +104,31 @@
 		<!-- Short description -->
 		<div class="field {{ $errors->has('shortDescription') ? 'error': '' }}">
 			<label for="shortDescription">Brief description</label>
-			<textarea name="shortDescription" rows="2" placeholder="e.g. The project is a web page for personal financial organization">{{ old('shortDescription') }}</textarea>
+			<textarea id="shortDescription" name="shortDescription" rows="2" placeholder="e.g. The project is a web page for personal financial organization">{{ old('shortDescription') }}</textarea>
 		</div>
 		<!-- Long description -->
 		<div class="field {{ $errors->has('longDescription') ? 'error': '' }}">
 			<label for="longDescription">Detailed description</label>
-			<textarea name="longDescription" placeholder="e.g. The project consists of a single page application where users can sign up or login. It includes...">{{ old('longDescription') }}</textarea>
+			<textarea id="longDescription" name="longDescription" placeholder="e.g. The project consists of a single page application where users can sign up or login. It includes...">{{ old('longDescription') }}</textarea>
 		</div>
 		<!-- Pitch video -->
 		<div class="field {{ $errors->has('videoPitch') ? 'error': '' }}">
 			<label for="videoPitch">Pitch video</label>
-			<input type="text" name="videoPitch"  value="{{ old('videoPitch') }}" placeholder="e.g. https://youtube.com/watch?v=238028302">
+			<input type="text" id="videoPitch" name="videoPitch"  value="{{ old('videoPitch') }}" placeholder="e.g. https://youtube.com/watch?v=238028302">
 		</div>
 		<!-- Register button -->
-		<button id="registerButton" type="submit" class="ui primary submit button">Register project</button>
+		<button id="registerButton" type="button" class="ui primary submit button">Register project</button>
 		<!-- Error message -->
-		<div class="ui error message"></div>
+		<div class="ui error message">
+			<div class="header">Whoops! Something went wrong.</div>
+			@if($errors->any())
+				<ul>
+					@foreach ($errors->all() as $error)
+						<li>{{ $error }}</li>
+					@endforeach
+				</ul>
+			@endif
+		</div>
 	</form>
 </div>
 @section('scripts')
@@ -136,7 +136,7 @@
 	/* Upload new image */
 	$(".imgUploader").click(function(event) {
 		event.preventDefault();
-		$("#imgInput").click();
+		$("#projectImage").click();
 	});
 
 	function validateImage(file) {
@@ -147,7 +147,7 @@
 	function fillDummy() {
 		$('input[name=projectName]').val('Some project title');
 		$("select[name=courses]").val('1');
-		$('input[name=createTeam]').val('Some team name');
+		$('input[name=newTeam]').val('Some team name');
 		let labels = $("#labels option").slice(1,4).toArray().map(t => t.value);
 		$('#labels').dropdown('set selected', labels);
 		let skillsets = $('#skillsets option').slice(1,5).toArray().map(t => t.value);
@@ -184,66 +184,56 @@
 	/* Register button validation */
 	$('.ui.form').form({
 		fields: {
-			projectImage: {
-				identifier: 'projectImage',
-				rules:[{
-					type: 'empty',
-					prompt: 'Please enter a project image.'
-				}]
-			},
 			projectName: {
 				identifier:'projectName',
 				rules:[{
-					type: 'empty',
-					prompt: 'Please enter a project name.'
+					type: 'empty'
 				}]
 			},
-			createTeam: {
-				identifier: 'createTeam',
-				rules: ["empty", "maxLength[30]"],
-				prompt: 'Please enter a team name.',
-				optional: false
+			newTeam: {
+				identifier: 'newTeam',
+				optional: true
+				rules: [{
+					type: 'maxLength[30]',
+				}],
 			},
 			courses: {
 				identifier: 'courses',
 				rules: [{
-					type: 'minCount[1]',
-					prompt: 'Please select an associated course.'
+					type: 'minCount[1]'
 				}]
 			},
 			label: {
-				identifier: 'label[]',
+				identifier: 'labels[]',
 				rules: [{
 					type: 'minCount[1]',
-					prompt: 'Please select at least one label.'
 				}]
 			},
 			skillsets: {
 				identifier: 'skillsets[]',
 				rules: [{
 					type: 'minCount[1]',
-					prompt: 'Please select at least one skillset.'
 				}]
 			},
 			milestone: {
 				identifier: 'milestone',
 				rules: [{
 					type: 'empty',
-					prompt: 'Please enter current milestone.'
 				}]
 			},
 			shortDescription: {
 				identifier: 'shortDescription',
 				rules: [{
-					type: 'empty',
-					prompt: 'Please enter a brief project description.'
+						type: 'empty'
+					},
+					{
+						type: 'maxLength[280]'
 				}]
 			},
 			longDescription: {
 				identifier: 'longDescription',
 				rules: [{
-					type: 'empty',
-					prompt: 'Please enter a detailed project description.'
+					type: 'empty'
 				}]
 			},
 			videoPitch: {
@@ -262,6 +252,7 @@
 			}
 		},
 		onFailure:function() {
+			console.log('failed registration');
 			return false;
 		},
 		onSuccess:function() {

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -38,39 +38,32 @@
 				<option value="">e.g. Web development class</option>
 				@if(isset($courses))
 					@foreach($courses->all() as $course)
-						<option value="{{ $course->id }}">{{ $course->name }}</option>
+						<option value="{{ $course->id }}" {{ (old('course') == $course->id ? 'selected' : '') }}>{{ $course->name }}</option>
 					@endforeach
 				@endif
 			</select>
 		</div>
 		<!-- Associated team -->
-		<div class="ui placeholder segment">
-			<div class="ui two column very relaxed stackable grid">
-				<div class="column responsive-segment">
-					<div class="field associatedTeam">
-						<label for="existingTeam">Choose an existing team</label>
-						<select id="existingTeam" name="existingTeam" class="ui search dropdown team {{ $errors->has('existingTeam') || $errors->has('bothTeams') ? 'error': '' }}" value="{{ old('existingTeam') }}" onchange="selectTeam()">
-							<option value="">My teams</option>
-							@if(isset($teams))
-								@foreach($teams->all() as $team)
-									<option value="{{ $team->id }}">{{ $team->name }}</option>
-								@endforeach
-							@endif
-						</select>
-					</div>
-				</div>
-				<div class="ui horizontal divider">
-					Or
-				</div>
-				<div class="column responsive-segment">
-					<div class="field associatedTeam">
-						<label for="newTeam">Create a new team</label>
-						<input id="newTeam" type="text" name="newTeam" placeholder="Create a new team" value="{{ old('newTeam')}}" onchange="createNewTeam()">
-					</div>
-				</div>
+		<div class="fields">
+			<div class="seven wide field {{ $errors->has('existingTeam') || $errors->has('bothTeams') ? 'error': '' }}">
+				<label for="existingTeam">Choose an existing team</label>
+				<select id="existingTeam" name="existingTeam" class="ui search dropdown team" value="{{ old('existingTeam') }}" onchange="selectTeam()">
+					<option value="">My teams</option>
+					@if(isset($teams))
+						@foreach($teams->all() as $team)
+							<option value="{{ $team->id }}">{{ $team->name }}</option>
+						@endforeach
+					@endif
+				</select>
 			</div>
-			<div class="ui vertical divider">
-				Or
+			<div class="two wide two-column-divider">
+				<p style="font-weight: bold; font-size: 2rem; color: black; text-align: center; margin-top: 50%">OR</p>
+			</div>
+			<div class="seven wide field {{ $errors->has('newTeam') || $errors->has('bothTeams') ? 'error': '' }}">
+				<div class="field associatedTeam">
+					<label for="newTeam">Create a new team</label>
+					<input id="newTeam" type="text" name="newTeam" placeholder="Create a new team" value="{{ old('newTeam')}}" onchange="createNewTeam()">
+				</div>
 			</div>
 		</div>
 		<!-- Labels -->
@@ -80,7 +73,7 @@
 				<option value="">e.g. Finance</option>
 				@if(isset($labels))
 					@foreach($labels->all() as $label)
-						<option value="{{ $label->id }}">{{ $label->name }}</option>
+						<option value="{{ $label->id }}" {{ (collect(old('labels'))->contains($label->id)) ? 'selected' : '' }}>{{ $label->name }}</option>
 					@endforeach
 				@endif
 			</select>
@@ -92,7 +85,7 @@
 				<option value="">e.g. Java, HTML</option>
 				@if(isset($skillsets))
 					@foreach($skillsets->all() as $skillset)
-						<option value="{{ $skillset->id }}">{{ $skillset->name }}</option>
+						<option value="{{ $skillset->id }}" {{ (collect(old('skillsets'))->contains($skillset->id)) ? 'selected' : '' }}>{{ $skillset->name }}</option>
 					@endforeach
 				@endif
 			</select>
@@ -183,24 +176,6 @@
 		$(".associatedTeam").removeClass("error");
 		$("#newTeam").val("");
 	}
-
-	/* Responsiveness not handled by Semantic */
-	function setResponsiveProperties(mobile) {
-		$(".ui.divider").hide();
-		if (mobile.matches) { // If media query matches
-			$(".ui.horizontal.divider").show();
-			$(".responsive-segment").addClass("row").removeClass("column");
-
-		}
-		else {
-			$(".ui.vertical.divider").show();
-			$(".responsive-segment").addClass("column").removeClass("row");
-		}
-	}
-
-	let mobile = window.matchMedia("(max-width: 767px)");
-	setResponsiveProperties(mobile);
-	mobile.addListener(setResponsiveProperties);
 
 	/* Semantic dropdown set up  */
 	$('.ui.dropdown').dropdown({ clearable: true });

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -118,7 +118,7 @@
 			<input type="text" id="videoPitch" name="videoPitch"  value="{{ old('videoPitch') }}" placeholder="e.g. https://youtube.com/watch?v=238028302">
 		</div>
 		<!-- Register button -->
-		<button id="registerButton" type="button" class="ui primary submit button">Register project</button>
+		<button id="registerButton" type="submit" class="ui primary submit button">Register project</button>
 		<!-- Error message -->
 		<div class="ui error message">
 			<div class="header">Whoops! Something went wrong.</div>

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -29,7 +29,7 @@
 		<!-- Project name -->
 		<div class="field {{ $errors->has('projectName') ? 'error': '' }}">
 			<label for="projectName">Project name</label>
-			<input type="text" id="projectName"" name="projectName" placeholder="e.g. Best project" value="{{ old('projectName') }}">
+			<input type="text" id="projectName" name="projectName" placeholder="e.g. Best project" value="{{ old('projectName') }}">
 		</div>
 		<!-- Associated course -->
 		<div class="field {{ $errors->has('course') ? 'error': '' }}">
@@ -73,7 +73,7 @@
 				<option value="">e.g. Finance</option>
 				@if(isset($labels))
 					@foreach($labels->all() as $label)
-						<option value="{{ $label->id }}" {{ (collect(old('labels'))->contains($label->id)) ? 'selected' : '' }}>{{ $label->name }}</option>
+						<option value="{{ $label->id }}">{{ $label->name }}</option>
 					@endforeach
 				@endif
 			</select>
@@ -85,7 +85,7 @@
 				<option value="">e.g. Java, HTML</option>
 				@if(isset($skillsets))
 					@foreach($skillsets->all() as $skillset)
-						<option value="{{ $skillset->id }}" {{ (collect(old('skillsets'))->contains($skillset->id)) ? 'selected' : '' }}>{{ $skillset->name }}</option>
+						<option value="{{ $skillset->id }}">{{ $skillset->name }}</option>
 					@endforeach
 				@endif
 			</select>


### PR DESCRIPTION
# Changes
- Front-end prevents the scenario in which the user associates the project with an existing team *and* creates a new one at the same time.
- Restructured team-association form to properly use Semantic UI fields (for input validation and input display).
- Removed CSS classes that were not being used anywhere.
- Removed unnecessary custom prompts from Semantic UI input validation.
- Image validation now accepts .jpg and is consistent with other image validations across the app.
- Removed placeholder image - image preview only shows after successful load.

Partially fixes #102 

# Missing 
- [x] Adjusting field names in projects controller
- [x] Remove project image as a required field in project controller. 
- [ ] Blocked by #110 