### PR TITLE
Project Details (redirect and image display)

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -6,6 +6,7 @@ use App\Project;
 use App\Tag;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rule;
 
 class ProjectController extends Controller
@@ -56,7 +57,7 @@ class ProjectController extends Controller
 			]
 		]);
 
-		$project = $this->saveRecord($attributes);
+		$project = $this->saveRecord($attributes, $request->file('projectImage'));
 		if (!$project->exists) {
 			abort(500);
 		}
@@ -67,14 +68,16 @@ class ProjectController extends Controller
 		return view('projects.details', ['project' => $project]);
 	}
 
-	private function saveRecord(array $attributes) {
+	private function saveRecord(array $attributes, $image) {
+		$path = isset($image) ? Storage::putFile('public', $image) : null;
+
 		return Project::create([
 			'name' => $attributes['projectName'],
 			'video' => $this->formatYouTubeUrl($attributes['videoPitch']),
 			'long_description' => $attributes['longDescription'],
 			'short_description' => $attributes['shortDescription'],
 			'course_id' => $attributes['course'],
-			'photo' => $attributes['projectImage']
+			'photo' => Storage::url($path)
 		]);
 	}
 

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -64,7 +64,7 @@ class ProjectController extends Controller
 		$project->tags()->attach($attributes['skillsets']);
 		$project->tags()->attach($attributes['labels']);
 
-		return view('projects', ['project' => $project]);
+		return view('projects.details', ['project' => $project]);
 	}
 
 	private function saveRecord(array $attributes) {

--- a/resources/views/projects/details.blade.php
+++ b/resources/views/projects/details.blade.php
@@ -10,6 +10,12 @@
 		<div class="ui embed detail-container">
 			<iframe src="{{ $project->video }}" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 		</div>
+		<!-- Project Image -->
+		<div class="ui left aligned detail-container image-container">
+			<div class="preview-container">
+				<img id="preview" src="<?php echo asset($project->photo) ?>" alt="Project Image" class="ui small image preview"/>
+			</div>
+		</div>
 		<!-- Short description -->
 		<div class="ui left aligned detail-container">
 			<p><strong>Description</strong></p>

--- a/resources/views/projects/details.blade.php
+++ b/resources/views/projects/details.blade.php
@@ -37,7 +37,7 @@
 		<!-- Associated course -->
 		<div class="ui left aligned detail-container">
 			<p><strong>Associated course</strong></p>
-			<p>e.g. Computer Graphics</p>
+			<p>{{ $project->course->name }}</p>
 		</div>
 		<!-- Associated team -->
 		<div class="ui left aligned detail-container">


### PR DESCRIPTION
Fix for issue: #108 
- redirect to `projects.details` after creation
- display project name in `projects.details`
- added correct storage for project images
- now displaying project image to `projects.details` @katiearriagam cómo queremos q se vea? 

> (this is how it looks like rn)

![Screen Shot 2019-04-04 at 8 56 25 PM](https://user-images.githubusercontent.com/6790709/55601076-34ea9380-571c-11e9-958f-40a45088fcb9.png)
