### PR TITLE
Initial navigation dropdown menu for students and teachers

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -5,21 +5,47 @@ $color-dark: #333;
 $color-white: #fff;
 
 
-.ui.menu.menu.bluemarketheader {
+.ui.menu.bluemarket-header {
 	background: $color-dark;
-	padding-top: 10px;
+	border: none;
 	margin: 0;
+	padding: 0 5px;
+
 	.item.item {
 		color: $color-white;
+		height: 100%;
 		&.active {
 			color: $color-white;
 			border-color: $color-primary;
 		}
-		&:hover {
+		&:hover:hover {
 			color: $color-primary;
-			border-color: $color-primary;
 		}
 	}
+}
+
+.ui.popup.vertical {
+	background: $color-dark;
+
+	&:before {
+		background: $color-dark;
+	}
+
+	.user-dropdown-menu.item {
+		color: $color-white;
+		background: $color-dark;
+		&.active {
+			color: $color-white;
+			border-color: $color-primary;
+		}
+		&:hover:hover {
+			color: $color-primary;
+		}
+	}
+}
+
+.ui.mini.circular.image.user-avatar {
+	width: 25px;
 }
 
 .ui.button {

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -27,7 +27,7 @@ $color-white: #fff;
 .ui.popup.vertical {
 	background: $color-dark;
 
-	&:before {
+	&::before {
 		background: $color-dark;
 	}
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -49,7 +49,7 @@
 							<i class="dropdown icon"></i>
 						</a>
 						<a id="user-menu-item" class="browse item">
-							<img class="ui mini circular image user-avatar" src="{{ isset(Auth::user()->picture_url) ? Auth::user()->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=K' }}"/>
+							<img class="ui mini circular image user-avatar" src="{{ isset(Auth::user()->picture_url) ? Auth::user()->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}"/>
 							<i class="dropdown icon"></i>
 						</a>
 					</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,14 +14,53 @@
 	<link href="{{ mix('css/app.css') }}" rel="stylesheet">
 </head>
 <body>
-	<div class="ui secondary pointing menu bluemarketheader" id="bluemarketheader">
-		<div class="right menu">
+	<div class="ui secondary pointing menu bluemarket-header" id="bluemarket-header">
+		<div class="menu">
 			<a class="item {{ Request::is('/') ? 'active' : '' }}" href="/"> Home </a>
 			<a class="item {{ Request::is('projects') ? 'active' : '' }}" href="{{ action('ProjectController@index') }}">
 				Projects
 			</a>
+		</div>
+		<div class="right menu">
 			@if(Auth::user())
-				<a class="item" href="{{ route('logout') }}">Logout</a>
+				@if(Auth::user()->role ==Config::get('enum.user_roles')['student'])
+					<div class="ui menu bluemarket-header">
+						<a id="add-menu-item" class="browse item">
+							<i class="plus icon"></i>
+							<i class="dropdown icon"></i>
+						</a>
+						<a id="user-menu-item" class="browse item">
+							<img class="ui mini circular image user-avatar" src="{{ isset(Auth::user()->picture_url) ? Auth::user()->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=K' }}"/>
+							<i class="dropdown icon"></i>
+						</a>
+					</div>
+					<div id="add-menu" class="ui vertical popup transition hidden">
+						<a class="item user-dropdown-menu" href="{{ url('projects/create') }}">New project</a>
+						<a class="item user-dropdown-menu" href="{{ url('teams/create') }}">New team</a>
+					</div>
+					<div id="user-menu" class="ui vertical popup transition hidden">
+						<a class="item user-dropdown-menu" href="{{ url('users', Auth::id()) }}">My profile</a>
+						<a class="item user-dropdown-menu" href="{{ route('logout') }}">Logout</a>
+					</div>
+				@elseif(Auth::user()->role ==Config::get('enum.user_roles')['teacher'])
+					<div class="ui menu bluemarket-header">
+						<a id="add-menu-item" class="browse item">
+							<i class="plus icon"></i>
+							<i class="dropdown icon"></i>
+						</a>
+						<a id="user-menu-item" class="browse item">
+							<img class="ui mini circular image user-avatar" src="{{ isset(Auth::user()->picture_url) ? Auth::user()->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=K' }}"/>
+							<i class="dropdown icon"></i>
+						</a>
+					</div>
+					<div id="add-menu" class="ui vertical popup transition hidden">
+						<a class="item user-dropdown-menu" href="{{ url('courses/create') }}">New course</a>
+					</div>
+					<div id="user-menu" class="ui vertical popup transition hidden">
+						<a class="item user-dropdown-menu" href="{{ url('courses') }}">My courses</a>
+						<a class="item user-dropdown-menu" href="{{ route('logout') }}">Logout</a>
+					</div>
+				@endif
 			@else
 				<a class="item {{ Request::is('login') ? 'active' : '' }}" id="loginBtn" href="{{ route('login') }}">
 					Login
@@ -35,6 +74,17 @@
 	<script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.js"></script>
 	<script src="{{ mix('js/inputValidation.js') }}"></script>
+	<script>
+		$('#user-menu-item').popup({
+			popup: $('#user-menu'),
+			on: 'click'
+		});
+
+		$('#add-menu-item').popup({
+			popup: $('#add-menu'),
+			on: 'click'
+		});
+	</script>
 	@yield('scripts')
 </body>
 </html>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -16,7 +16,7 @@
 <body>
 	<div class="ui secondary pointing menu bluemarket-header" id="bluemarket-header">
 		<div class="menu">
-			<a class="item {{ Request::is('/') ? 'active' : '' }}" href="/"> Home </a>
+			<a class="item {{ Request::is('/') ? 'active' : '' }}" href="/">Home</a>
 			<a class="item {{ Request::is('projects') ? 'active' : '' }}" href="{{ action('ProjectController@index') }}">
 				Projects
 			</a>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -30,7 +30,7 @@
 							<i class="dropdown icon"></i>
 						</a>
 						<a id="user-menu-item" class="browse item">
-							<img class="ui mini circular image user-avatar" src="{{ isset(Auth::user()->picture_url) ? Auth::user()->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=K' }}"/>
+							<img class="ui mini circular image user-avatar" src="{{ isset(Auth::user()->picture_url) ? Auth::user()->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}"/>
 							<i class="dropdown icon"></i>
 						</a>
 					</div>


### PR DESCRIPTION
# Changes 

- This PR adds dropdown menus for students and teachers. The following routes are defined according to the current functionality. 

## Both (no changes here!)
- Home => `/`
- Projects=> `/projects`

## Students
- New project => `/projects/create`
- New team => `/teams/create`
- My profile => `/users/{id}`
- Logout => `/logout`

## Teachers
- New course => `/courses/create`
- My courses => `/courses`
- Logout => `/logout`

# Example in mobile view
![image](https://user-images.githubusercontent.com/14140121/55704283-57411300-59a1-11e9-84b4-3f1252a6f342.png)

# Fixes
- #116 
- #117 