### PR TITLE
Add project collaborators tab to project details

### DIFF
--- a/app/Project.php
+++ b/app/Project.php
@@ -12,6 +12,7 @@ class Project extends Model
 	 * @var array
 	 */
 	protected $guarded = [];
+
 	// Get all the tags of a project (skills + labels)
 	public function tags() {
 		return $this->belongsToMany('App\Tag', 'tag_project', 'project_id', 'tag_id');
@@ -31,6 +32,7 @@ class Project extends Model
 	public function course() {
 		return $this->belongsTo('App\Course');
 	}
+
 	// Get the team the project belongs to
 	public function team() {
 		return $this->belongsTo('App\Team');

--- a/resources/views/projects/details.blade.php
+++ b/resources/views/projects/details.blade.php
@@ -95,26 +95,27 @@
 	</div>
 	<div class="ui bottom attached tab segment" data-tab="collaborators">
 		<div class="ui stackable grid">
-			<div class="eight wide column {{ count($project->team->members) <= 0 ? 'hidden' : '' }}">
-				<h2>Owners</h2>
-				<table class="ui striped table">
-					<tbody>
-						@foreach($project->team->members as $member)
-							<tr class="selectable">
-								<td>
-									<a href="{{ url('users', $member->id) }}">
-										<img class="ui mini circular image" src="{{ isset($member->picture_url) ? $member->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}" style="display: inline; margin-right: 10px;"/>
-										{{ $member->name }}
-									</a>
-								</td>
-							</tr>
-						@endforeach
-					</tbody>
-				</table>
-			</div>
-			<!-- TODO: remove isset condition (currently prevents view from crashing) -->
-			@if(isset($project->suppliers))
-				<div class="eight wide column {{ count($project->suppliers) <= 0 ? 'hidden' : '' }}">
+			@if(isset($project->team->members) && count($project->team->members) > 0)
+				<div class="eight wide column">
+					<h2>Owners</h2>
+					<table class="ui striped table">
+						<tbody>
+							@foreach($project->team->members as $member)
+								<tr class="selectable">
+									<td>
+										<a href="{{ url('users', $member->id) }}">
+											<img class="ui mini circular image" src="{{ isset($member->picture_url) ? $member->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}" style="display: inline; margin-right: 10px;"/>
+											{{ $member->name }}
+										</a>
+									</td>
+								</tr>
+							@endforeach
+						</tbody>
+					</table>
+				</div>
+			@endif
+			@if(isset($project->suppliers) && count($project->suppliers) > 0)
+				<div class="eight wide column">
 					<h2>Suppliers</h2>
 					<table class="ui striped table">
 						<tbody>

--- a/resources/views/projects/details.blade.php
+++ b/resources/views/projects/details.blade.php
@@ -104,7 +104,7 @@
 								<tr class="selectable">
 									<td>
 										<a href="{{ url('users', $member->id) }}">
-											<img class="ui mini circular image" src="{{ isset($member->picture_url) ? $member->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}" style="display: inline; margin-right: 10px;"/>
+											<img class="ui mini circular image" src="{{ isset($member->picture_url) ? $member->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}" alt="{{ $member->name }}" style="display: inline; margin-right: 10px;"/>
 											{{ $member->name }}
 										</a>
 									</td>
@@ -123,7 +123,7 @@
 								<tr class="selectable">
 									<td>
 										<a href="{{ url('users', $supplier->id) }}">
-											<img class="ui mini circular image" src="{{ isset($supplier->picture_url) ? $supplier->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}" style="display: inline; margin-right: 10px;"/>
+											<img class="ui mini circular image" src="{{ isset($supplier->picture_url) ? $supplier->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}" alt="{{ $supplier->name }}" style="display: inline; margin-right: 10px;"/>
 											{{ $supplier->name }}
 										</a>
 									</td>

--- a/resources/views/projects/details.blade.php
+++ b/resources/views/projects/details.blade.php
@@ -9,6 +9,7 @@
 	<h1>{{ $project->name }}</h1>
 	<div class="ui top attached tabular menu">
 		<a class="active item" data-tab="overview">Overview</a>
+		<a class="item" data-tab="collaborators">Collaborators</a>
 	</div>
 	<div class="ui bottom attached active tab segment" data-tab="overview">
 		<div class="ui stackable two column grid">
@@ -92,5 +93,53 @@
 			</div>
 		</div>
 	</div>
+	<div class="ui bottom attached tab segment" data-tab="collaborators">
+		<div class="ui stackable grid">
+			<div class="eight wide column {{ count($project->team->members) <= 0 ? 'hidden' : '' }}">
+				<h2>Owners</h2>
+				<table class="ui striped table">
+					<tbody>
+						@foreach($project->team->members as $member)
+							<tr class="selectable">
+								<td>
+									<a href="{{ url('users', $member->id) }}">
+										<img class="ui mini circular image" src="{{ isset($member->picture_url) ? $member->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}" style="display: inline; margin-right: 10px;"/>
+										{{ $member->name }}
+									</a>
+								</td>
+							</tr>
+						@endforeach
+					</tbody>
+				</table>
+			</div>
+			<!-- TODO: remove isset condition (currently prevents view from crashing) -->
+			@if(isset($project->suppliers))
+				<div class="eight wide column {{ count($project->suppliers) <= 0 ? 'hidden' : '' }}">
+					<h2>Suppliers</h2>
+					<table class="ui striped table">
+						<tbody>
+							@foreach($project->suppliers as $supplier)
+								<tr class="selectable">
+									<td>
+										<a href="{{ url('users', $supplier->id) }}">
+											<img class="ui mini circular image" src="{{ isset($supplier->picture_url) ? $supplier->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}" style="display: inline; margin-right: 10px;"/>
+											{{ $supplier->name }}
+										</a>
+									</td>
+								</tr>
+							@endforeach
+						</tbody>
+					</table>
+				</div>
+			@endif
+		</div>
+	</div>
 </div>
+
+@section('scripts')
+<script>
+	/* Semantic UI setup */
+	$('.menu .item').tab();
+</script>
+@endsection
 @endsection


### PR DESCRIPTION
## Changes
- Adds a tab to the project details that shows the owners (team members of the owner teams) and the suppliers. 
- Nit: fixed whitespaced in Project.php

## To-do 
- We need to expose `$project->suppliers` from back-end (@osdagoso -> creo que esto cae dentro de lo nuestro but please correct me if I'm wrong).

## Related
- This is relevant for #35 and the project details view in general.