### PR TITLE
Notification center view enhancements 

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -70,7 +70,7 @@ class NotificationController extends Controller
 				break;
 		}
 
-		return Auth::id();
+		return ['success' => 'success'];
 	}
 
 	/**
@@ -97,6 +97,6 @@ class NotificationController extends Controller
 				break;
 		}
 
-		return Auth::id();
+		return ['success' => 'success'];
 	}
 }

--- a/resources/js/utilities.js
+++ b/resources/js/utilities.js
@@ -1,4 +1,4 @@
-import { format, render, cancel } from 'timeago.js';
+import { format } from 'timeago.js';
 import _debounce from 'lodash.debounce';
 
 /* global functions */

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -343,7 +343,7 @@ $color-white: #fff;
 	}
 }
 
-.ui.stackable.grid:not(.notifications-grid) {
+.ui.stackable.grid {
 	margin: 0 auto;
 	margin-top: 10px;
 
@@ -517,12 +517,11 @@ $color-white: #fff;
 	}
 }
 
-.ui.grid .column.notification-column {
-	padding: 0 1rem;
-	display: inline-block;
-	vertical-align: middle;
+.column.wide.notifications-list:not(.active) {
+	display: none;
+}
 
-	&.user-avatar-column {
-		width: 40px;
-	}
+.ui.table .notification-column {
+	padding: 0 1rem;
+	vertical-align: middle;
 }

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -18,47 +18,54 @@
 </style>
 <div class="padded content">
 	<div class="ui stackable grid">
-		<div class="row">
-			<h1>Project notifications</h1>
+		<div class="four wide column">
+			<div id="notifications-menu" class="ui vertical fluid menu">
+				<a class="active teal item" data-item="projects">
+					Project invites
+					<div class="ui {{ count($projectInvites) > 0 ? 'teal' : '' }} label">{{ count($projectInvites) }}</div>
+				</a>
+				<a class="item" data-item="teams">
+					Team invites
+					<div class="ui {{ count($teamInvites) > 0 ? 'teal' : '' }} label">{{ count($teamInvites) }}</div>
+				</a>
+			</div>
 		</div>
-		<div class="row">
-			<table class="ui tablet stackable table">
+		<div class="eleven wide column notifications-list active" data-item="projects">
+			<table class="ui stackable table notifications-table">
 				<tbody>
 					@foreach($projectInvites as $projectInvite)
 						<tr data-invite-type="{{ Config::get('enum.invite_type')['project'] }}" data-id="{{ $projectInvite->id }}">
-							<td>
-								<div class="ui stackable grid notifications-grid">
-									<div class="twelve wide column">
-										<div class="ui stackable grid">
-											<div class="wide column notification-column user-avatar-column">
-												<img src="{{ isset($projectInvite->team->leader->picture_url) ? $projectInvite->team->leader->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}" alt="Sender image" class="ui tiny image squared-image"/>
-											</div>
-											<div class="ten wide column notification-column">
-												<p>
-													<a href={{ action('UserController@show', ['id' => $projectInvite->team->leader->id]) }}>
-														{{ $projectInvite->team->leader->name }}
-													</a>
-													invited you to join their project
-													<a href={{ action('ProjectController@show', ['id' => $projectInvite->id]) }}>
-														{{ $projectInvite->name }}
-													</a>
-													.
-												</p>
-											</div>
-											<div class="four wide column notification-column">
-												<div class="four wide column notification-column">
-													<p class="date needs-datetimeago" data-datetime="{{ $projectInvite->pivot->created_at }}">{{ $projectInvite->pivot->created_at }}</p>
+							<td class="notification-column">
+								<div class="ui two column stackable grid">
+										<div class="column">
+											<div class="ui two column grid">
+												<div class="two wide column user-avatar-column">
+													<img src="{{ isset($projectInvite->team->leader->picture_url) ? $projectInvite->team->leader->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}" alt="Sender image" class="ui tiny image squared-image"/>
+												</div>
+												<div class="fourteen wide column">
+													<span>
+														<a href={{ action('UserController@show', ['id' => $projectInvite->team->leader->id]) }}>
+															{{ $projectInvite->team->leader->name }}
+														</a>
+														invited you to join their project
+														<a href={{ action('ProjectController@show', ['id' => $projectInvite->id]) }}>
+															{{ $projectInvite->name }}
+														</a>
+														.
+													</span>
 												</div>
 											</div>
 										</div>
-									</div>
-									<div class="four wide column">
-										<div class="ui padded grid">
-											<div class="eight wide column notification-column">
-												<p class="notification-option-icon accept-invite"><i class="link big check circle outline icon green"></i></p>
+										<div class="column">
+											<div class="ui three column grid">
+												<div class="ten wide column">
+													<span class="date needs-datetimeago" data-datetime="{{ $projectInvite->pivot->created_at }}">{{ $projectInvite->pivot->created_at }}</span>
+												</div>
+												<div class="three wide right aligned column ">
+												<span class="notification-option-icon accept-invite"><i class="link big check circle icon green"></i></span>
 											</div>
-											<div class="eight wide column notification-column">
-												<p class="notification-option-icon decline-invite"><i class="link big times circle outline icon red"></i></p>
+											<div class="three wide right aligned column">
+												<span class="notification-option-icon decline-invite"><i class="link big times circle icon red"></i></span>
 											</div>
 										</div>
 									</div>
@@ -68,46 +75,47 @@
 					@endforeach
 				</tbody>
 			</table>
+			<div class="ui message {{ count($projectInvites) > 0 ? 'hidden' : ''}}">
+				<p class="header">No pending project invites</p>
+				<p>Looks like you don't have any pending notifications here!</p>
+			</div>
 		</div>
-		<div class="row">
-			<h1>Team notifications</h1>
-		</div>
-		<div class="row">
-			<table class="ui tablet stackable table">
+		<div class="eleven wide column notifications-list" data-item="teams">
+			<table class="ui stackable table notifications-table">
 				<tbody>
 					@foreach($teamInvites as $teamInvite)
 						<tr data-invite-type="{{ Config::get('enum.invite_type')['team'] }}" data-id="{{ $teamInvite->id }}">
-							<td>
-								<div class="ui stackable grid notifications-grid">
-									<div class="twelve wide column">
-										<div class="ui stackable grid">
-											<div class="wide column notification-column user-avatar-column">
-												<img src="{{ isset($teamInvite->leader->picture_url) ? $teamInvite->leader->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}" alt="Sender image" class="ui tiny image squared-image"/>
-											</div>
-											<div class="ten wide column notification-column">
-												<p>
-													<a href={{ action('UserController@show', ['id' => $teamInvite->leader->id]) }}>
-														{{ $teamInvite->leader->name }}
-													</a>
-													invited you to join their team
-													<a href={{ action('TeamController@show', ['id' => $teamInvite->id]) }}>
-														{{ $teamInvite->name }}
-													</a>
-													.
-												</p>
-											</div>
-											<div class="four wide column notification-column">
-												<p class="date needs-datetimeago" data-datetime="{{ $teamInvite->pivot->created_at }}">{{ $teamInvite->pivot->created_at }}</p>
+							<td class="notification-column">
+								<div class="ui two column stackable grid">
+										<div class="column">
+											<div class="ui two column grid">
+												<div class="two wide column user-avatar-column">
+													<img src="{{ isset($teamInvite->leader->picture_url) ? $teamInvite->leader->picture_url : 'https://dummyimage.com/400x400/3498db/ffffff.png&text=B' }}" alt="Sender image" class="ui tiny image squared-image"/>
+												</div>
+												<div class="fourteen wide column">
+													<span>
+														<a href={{ action('UserController@show', ['id' => $teamInvite->leader->id]) }}>
+															{{ $teamInvite->leader->name }}
+														</a>
+														invited you to join their team
+														<a href={{ action('TeamController@show', ['id' => $teamInvite->id]) }}>
+															{{ $teamInvite->name }}
+														</a>
+														.
+													</span>
+												</div>
 											</div>
 										</div>
-									</div>
-									<div class="four wide column">
-										<div class="ui padded grid">
-											<div class="eight wide column notification-column">
-												<p class="notification-option-icon accept-invite"><i class="link big check circle outline icon green"></i></p>
+										<div class="column">
+											<div class="ui three column grid">
+												<div class="ten wide column">
+													<span class="date needs-datetimeago" data-datetime="{{ $teamInvite->pivot->created_at }}">{{ $teamInvite->pivot->created_at }}</span>
+												</div>
+												<div class="three wide right aligned column ">
+												<span class="notification-option-icon accept-invite"><i class="link big check circle icon green"></i></span>
 											</div>
-											<div class="eight wide column notification-column">
-												<p class="notification-option-icon decline-invite"><i class="link big times circle outline icon red"></i></p>
+											<div class="three wide right aligned column">
+												<span class="notification-option-icon decline-invite"><i class="link big times circle icon red"></i></span>
 											</div>
 										</div>
 									</div>
@@ -117,6 +125,10 @@
 					@endforeach
 				</tbody>
 			</table>
+			<div class="ui message {{ count($teamInvites) > 0 ? 'hidden' : ''}}">
+				<p class="header">No pending team invites</p>
+				<p>Looks like you don't have any pending notifications here!</p>
+			</div>
 		</div>
 	</div>
 	<div id="success-modal" class="ui modal">
@@ -153,12 +165,38 @@
 @section('scripts')
 <script src="{{ mix('js/utilities.js')}}"></script>
 <script>
+	/* menu */
+	$("#notifications-menu .item").on("click", function() {
+		$(".active.teal.item").removeClass("active teal");
+		let selectedItem = $(this).data("item");
+		$(this).addClass("active teal");
+		$(".notifications-list").removeClass("active").hide();
+		$(`.notifications-list[data-item='${selectedItem}']`).addClass("active");
+		$(`.notifications-list[data-item='${selectedItem}']`).show();
+	});
+
 	/* render sent datetime for all invites*/
 	renderDateTimeAgoOnce();
 
+	/* Update menu on accept/decline invite */
+	function updateMenuContent(listType) {
+		// update menu label
+		let menuItemLabel = $(`.item[data-item='${listType}'] > .label`).text();
+		let itemNotificationCount = parseInt(menuItemLabel, 10) - 1;
+		$(`.item[data-item='${listType}'] > .label`).text(itemNotificationCount.toString());
+
+		if(itemNotificationCount <= 0) {
+			$(`.item[data-item='${listType}'] > .label`).removeClass("teal");
+
+			// update list associated with menu item
+			$(`.notifications-list[data-item='${listType}'] .ui.message`).show();
+		}
+	}
+
 	/* Handler for accept invite */
-	$(".accept-invite").on('click', function () {
-		let parenttr = $(this).closest("tr");
+	$(".accept-invite").on("click", function () {
+		const parenttr = $(this).closest("tr");
+		const listType = $(this).closest(".notifications-list").data("item");
 		const inviteType = parenttr.data("invite-type");
 		const id = parenttr.data("id");
 		$.ajax({
@@ -175,6 +213,7 @@
 			success: function(data) {
 				$("#success-modal").modal("show");
 				parenttr.remove();
+				updateMenuContent(listType);
 			},
 			error: function() {
 				$("#error-modal").modal("show");
@@ -186,7 +225,8 @@
 
 	/* Handler to decline invite */
 	$(".decline-invite").on('click', function () {
-		let parenttr = $(this).closest("tr");
+		const parenttr = $(this).closest("tr");
+		const listType = $(this).closest(".notifications-list").data("item");
 		const inviteType = parenttr.data("invite-type");
 		const id = parenttr.data("id");
 		$.ajax({
@@ -203,6 +243,7 @@
 			success: function(data) {
 				$("#success-modal-rejected-invite").modal("show");
 				parenttr.remove();
+				updateMenuContent(listType);
 			},
 			error: function() {
 				$("#error-modal").modal("show");

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -131,7 +131,7 @@
 			</div>
 		</div>
 	</div>
-	<div id="success-modal" class="ui modal">
+	<div id="success-modal" class="ui mini modal">
 		<div class="header">Success</div>
 		<div class="content">
 			<i class="check huge green circle icon"></i>
@@ -141,7 +141,7 @@
 			<button type="button" class="ui ok primary button">Done</button>
 		</div>
 	</div>
-	<div id="success-modal-rejected-invite" class="ui modal">
+	<div id="success-modal-rejected-invite" class="ui mini modal">
 		<div class="header">Success</div>
 		<div class="content">
 			<i class="check huge green circle icon"></i>
@@ -151,7 +151,7 @@
 			<button type="button" class="ui ok primary button">Done</button>
 		</div>
 	</div>
-	<div id="error-modal" class="ui modal">
+	<div id="error-modal" class="ui mini modal">
 		<div class="header">Something went wrong</div>
 		<div class="content">
 			<i class="times huge red circle icon"></i>


### PR DESCRIPTION
## Changes
- Fixed notification center layout
- Added menu for easy navigation between notification types (which allows for scalability in case we want to add more notifications in the future e.g. task assignations, milestone completed, etc).
- Added message that displays when there are no pending notifications.
- Removed import in `utilities.js`.

![notificationcentergif](https://user-images.githubusercontent.com/14140121/56876264-ca233400-6a0b-11e9-93dc-938a25d18c0b.gif)


## Updates
- Made modal smaller
![image](https://user-images.githubusercontent.com/14140121/56876540-ba0c5400-6a0d-11e9-98a4-fbcc8f961dac.png)
