### PR TITLE
Milestones fixes + merged milestones-ordered

### DIFF
--- a/app/Http/Controllers/MilestoneController.php
+++ b/app/Http/Controllers/MilestoneController.php
@@ -50,7 +50,7 @@ class MilestoneController extends Controller {
 
 		if($new_next_milestone)
 		{
-			$new_next_milestone->update(array('previous_milestone_id' => $milestone->id));
+			$new_next_milestone->update(['previous_milestone_id' => $milestone->id]);
 		}
 
 		return $milestone;
@@ -88,18 +88,18 @@ class MilestoneController extends Controller {
 
 			if($milestone_after_new_prev)
 			{
-				$milestone_after_new_prev->update(array('previous_milestone_id' => $milestone->id));
+				$milestone_after_new_prev->update(['previous_milestone_id' => $milestone->id]);
 			}
 
 			if($old_next_milestone)
 			{
 				if($old_prev_milestone)
 				{
-					$old_next_milestone->update(array('previous_milestone_id' => $old_prev_milestone->id));
+					$old_next_milestone->update(['previous_milestone_id' => $old_prev_milestone->id]);
 				}
 				else
 				{
-					$old_next_milestone->update(array('previous_milestone_id' => null));
+					$old_next_milestone->update(['previous_milestone_id' => null]);
 				}
 			}
 		}

--- a/app/Http/Controllers/MilestoneController.php
+++ b/app/Http/Controllers/MilestoneController.php
@@ -32,7 +32,7 @@ class MilestoneController extends Controller {
 		$validatedAttributes = request()->validate([
 			'name' => 'required|string',
 			'project_id' => 'required|int',
-			'previous_milestone_id' => 'required|int',
+			'previous_milestone_id' => 'int',
 		]);
 
 		$validatedAttributes['status'] = $request->get('status');
@@ -43,10 +43,15 @@ class MilestoneController extends Controller {
 			$validatedAttributes['done_date'] = $date;
 		}
 
+		$new_next_milestone = Project::find($validatedAttributes['project_id'])->next_milestone($validatedAttributes['previous_milestone_id']);
+
 		$milestone = Milestone::create($validatedAttributes);
 		abort_if(!$milestone->exists, 500);
 
-		Project::findOrFail($validatedAttributes['project_id'])->next_milestone($validatedAttributes['previous_milestone_id'])->update(array('previous_milestone_id' => $milestone->id));
+		if($new_next_milestone)
+		{
+			$new_next_milestone->update(array('previous_milestone_id' => $milestone->id));
+		}
 
 		return $milestone;
 	}

--- a/app/Project.php
+++ b/app/Project.php
@@ -46,6 +46,16 @@ class Project extends Model {
 		return $this->hasMany('App\Milestone');
 	}
 
+	public function first_milestone() {
+		return $this->milestones()
+			->where('previous_milestone_id', null)->first();
+	}
+
+	public function next_milestone(int $milestone_id) {
+		return $this->milestones()
+			->where('previous_milestone_id', $milestone_id)->first();
+	}
+
 	public function suppliers() {
 		return $this->belongsToMany('App\User', 'project_user', 'project_id', 'user_id')
 			->withPivot('accepted')

--- a/resources/views/components/projectCard.blade.php
+++ b/resources/views/components/projectCard.blade.php
@@ -25,8 +25,19 @@
 				@endforeach
 			</div>
 		@endif
-		<div class="extra content milestone">
-			<p>Shipping</p>
-		</div>
+		@if(count($project->milestones) > 0)
+			@php
+				$currentMilestone = $project->milestones->where('status', Config::get('enum.milestone_status')['current'])->first();
+			@endphp
+			@if($currentMilestone != null)
+				<div class="extra content milestone">
+					<p>{{ $currentMilestone->name }}</p>
+				</div>
+			@endif
+		@else
+			<div class="extra content milestone">
+				<p>On hold</p>
+			</div>
+		@endif
 	</div>
 </a>

--- a/resources/views/components/projectCard.blade.php
+++ b/resources/views/components/projectCard.blade.php
@@ -25,19 +25,19 @@
 				@endforeach
 			</div>
 		@endif
-		@if(count($project->milestones) > 0)
-			@php
-				$currentMilestone = $project->milestones->where('status', Config::get('enum.milestone_status')['current'])->first();
-			@endphp
-			@if($currentMilestone != null)
-				<div class="extra content milestone">
+		<div class="extra content milestone">
+			@if(count($project->milestones) > 0)
+				@php
+					$currentMilestone = $project->milestones->where('status', Config::get('enum.milestone_status')['current'])->first();
+				@endphp
+				@if($currentMilestone != null)
 					<p>{{ $currentMilestone->name }}</p>
-				</div>
+				@else
+					<p>On hold</p>
+				@endif
+			@else
+				<p>N/A</p>
 			@endif
-		@else
-			<div class="extra content milestone">
-				<p>On hold</p>
-			</div>
-		@endif
+		</div>
 	</div>
 </a>

--- a/resources/views/projects/details.blade.php
+++ b/resources/views/projects/details.blade.php
@@ -111,8 +111,10 @@
 				</div>
 				@if(count($project->milestones) > 0)
 					<div class="ui list milestone-section">
-					@foreach ($project->milestones as $milestone)
-
+					@for($i = 1; $i <= count($project->milestones); $i++)
+						@php
+							$milestone = $i > 1 ?  $project->next_milestone($milestone->id) : $project->first_milestone();
+						@endphp
 						@switch($milestone->status)
 						@case(Config::get('enum.milestone_status')['done'])
 						<div class="item done">
@@ -143,7 +145,7 @@
 							</div>
 						</div>
 						@endswitch
-					@endforeach
+					@endfor
 					</div>
 				@endif
 			</div>

--- a/resources/views/projects/milestones/form.blade.php
+++ b/resources/views/projects/milestones/form.blade.php
@@ -3,15 +3,16 @@
 	<div class="content">
 		<form class="ui form milestones {{ $name }} {{ $errors->any() ? 'error': '' }}">
 			<!-- Milestone name -->
-			<div class="field">
+			<div class="field {{ $errors->has('milestoneName') ? 'error': '' }}">
 				<label class="ui left" for="milestoneName">Name</label>
 				<input type="text" class="milestoneName" name="milestoneName">
 			</div>
 
 			<!-- Previous milestone -->
-			<div class="field">
+			<div class="field {{ $errors->has('prevMilestone') ? 'error': '' }}">
 				<label class="ui left" for="prevMilestone">Previous milestone</label>
 				<select class="ui fluid search dropdown prevMilestone" name="prevMilestone">
+					<option value=""></option>
 					@foreach ($project->milestones as $milestone)
 						<option value="{{ $milestone->id }}"> {{ $milestone->name }} </option>
 					@endforeach
@@ -19,18 +20,17 @@
 			</div>
 
 			<!-- Status -->
-			<div class="field">
+			<div class="field status {{ $errors->has('status') ? 'error': '' }}">
 				<label class="ui left" for="status">Status</label>
-				<select class="ui fluid search dropdown status" name="status">
+				<select class="ui fluid search dropdown status" name="status" onchange="updateDoneDate()">
 					<option value="0">Coming up</option>
 					<option value="2">Current</option>
 					<option value="1">Done</option>
 				</select>
 			</div>
 
-			<!-- TO DO: add an if statement so that done date is shown only if the status is done -->
 			<!-- Done date -->
-			<div class="field">
+			<div class="field doneDate {{ $errors->has('doneDate') ? 'error': '' }}">
 				<label class="ui left" for="doneDate">Done date</label>
 				<div class="ui calendar">
 					<div class="ui input left icon">
@@ -43,13 +43,6 @@
 			<!-- Error message -->
 			<div class="ui error message">
 				<h2 class="header">Whoops! Something went wrong.</h2>
-				@if($errors->any())
-					<ul>
-						@foreach ($errors->all() as $error)
-							<li>{{ $error }}</li>
-						@endforeach
-					</ul>
-				@endif
 			</div>
 			<input type="hidden" name="_milestoneID">
 		</form>

--- a/resources/views/projects/milestones/form.blade.php
+++ b/resources/views/projects/milestones/form.blade.php
@@ -12,7 +12,6 @@
 			<div class="field {{ $errors->has('prevMilestone') ? 'error': '' }}">
 				<label class="ui left" for="prevMilestone">Previous milestone</label>
 				<select class="ui fluid search dropdown prevMilestone" name="prevMilestone">
-					<option value=""></option>
 					@foreach ($project->milestones as $milestone)
 						<option value="{{ $milestone->id }}"> {{ $milestone->name }} </option>
 					@endforeach

--- a/resources/views/projects/milestones/form.blade.php
+++ b/resources/views/projects/milestones/form.blade.php
@@ -22,7 +22,7 @@
 			<!-- Status -->
 			<div class="field status {{ $errors->has('status') ? 'error': '' }}">
 				<label class="ui left" for="status">Status</label>
-				<select class="ui fluid search dropdown status" name="status" onchange="updateDoneDate()">
+				<select class="ui fluid search dropdown status" name="status">
 					<option value="0">Coming up</option>
 					<option value="2">Current</option>
 					<option value="1">Done</option>

--- a/resources/views/projects/milestones/form.blade.php
+++ b/resources/views/projects/milestones/form.blade.php
@@ -12,6 +12,9 @@
 			<div class="field {{ $errors->has('prevMilestone') ? 'error': '' }}">
 				<label class="ui left" for="prevMilestone">Previous milestone</label>
 				<select class="ui fluid search dropdown prevMilestone" name="prevMilestone">
+					@if($name == "edit")
+						<option value=""></option>
+					@endif
 					@foreach ($project->milestones as $milestone)
 						<option value="{{ $milestone->id }}"> {{ $milestone->name }} </option>
 					@endforeach

--- a/resources/views/projects/milestones/index.blade.php
+++ b/resources/views/projects/milestones/index.blade.php
@@ -77,7 +77,19 @@
 	/* Milestones
 	--------------------------------------------------------------------------------------- */
 
-	$("#new-milestone-modal").modal({ transition: "fade up" });
+	$("#new-milestone-modal").modal({
+		transition: "fade up",
+		onApprove: function() {
+			return false;
+		},
+	});
+
+	$("#edit-milestone-modal").modal({
+		transition: "fade up",
+		onApprove: function() {
+			return false;
+		},
+	});
 
 	$('.milestoneEditBtn').click(function(e) {
 		const id = $(this).data('id');
@@ -104,16 +116,6 @@
 
 	function submitForm(modalName) {
 		$(`.ui.form.milestones.${modalName}`).trigger('submit');
-	}
-
-	function updateDoneDate() {
-		console.log('Changed status');
-
-		if($(".status option:selected").val() != 1){
-			$(".doneDate").css("display", "none");
-			return false;
-		}
-		$(".doneDate").css("display", "block");
 	}
 
 	// Form validation

--- a/resources/views/projects/milestones/index.blade.php
+++ b/resources/views/projects/milestones/index.blade.php
@@ -126,7 +126,6 @@
 	// Form validation
 	const milestoneFields = {
 		milestoneName: ["empty", "maxLength[30]"],
-		prevMilestone: ["empty"],
 		estimatedDate: ["empty"],
 		status: ["empty"]
 	};
@@ -179,11 +178,15 @@
 		if(!values['done_date']) {
 			values['done_date'] = null;
 		}
+		if(!values['previous_milestone_id']){
+			values['previous_milestone_id'] = null;
+		}
 
 		if(isEdit) {
 			values['_method'] = 'PUT';
 			modalName = 'edit';
 		}
+		console.log(values);
 
 		$.ajax({
 			type: "POST",

--- a/resources/views/projects/milestones/index.blade.php
+++ b/resources/views/projects/milestones/index.blade.php
@@ -54,8 +54,6 @@
 <!-- Modals -->
 @include('projects.milestones.form', ['name' => 'new'])
 @include('projects.milestones.form', ['name' => 'edit'])
-
-<!-- TO DO: missing error validation for edit and delete -->
 <div id="delete-milestone-modal" class="ui tiny modal delete-milestone-modal">
 	<div class="header">Are you sure you want to delete this milestone?</div>
 	<div class="content">
@@ -115,6 +113,7 @@
 		estimatedDate: ["empty"],
 		status: ["empty"]
 	};
+
 	$(".ui.form.milestones.new").form({
 		fields: milestoneFields,
 		onSuccess: function(e) {
@@ -127,6 +126,7 @@
 			return false;
 		}
 	});
+
 	$(".ui.form.milestones.edit").form({
 		fields: milestoneFields,
 		onSuccess: function(e) {
@@ -178,15 +178,16 @@
 			dataType: 'json',
 			success: function (data) {
 				console.log(data);
-				// TODO: insert the milestone into the list
 				if(isEdit) {
 					alert('Saved!');
 					const rowIndex = $(`#${modalName}-milestone-modal`).find('.submitBtn').data('index');
 					updateTableEntry(data, rowIndex);
+					//updateProgress(data, rowIndex);
 				}
 				else {
 					alert('Your milestone has been created!');
 					addMilestone(data);
+					addToProgress(data);
 				}
 			},
 			error: function (xhr, status) {
@@ -253,6 +254,25 @@
 		$clone.find('.milestoneEditBtn').data('id', milestone.id);
 		$('#milestoneList').append($clone);
 		milestoneData.push(milestone);
+	}
+
+	function addToProgress(milestone) {
+		// Get the last milestone in ui list
+		var lastMilestone = $('.ui.list .item').last();
+		console.log(lastMilestone);
+
+		// Clone node
+		var newMilestone = lastMilestone.clone(true);
+		newMilestone.find('.header').html(milestone.name);
+		var icon = newMilestone.find('.icon');
+		icon.removeClass('green').removeClass('blue').removeClass('grey');
+		// Supposing it always adds a new milestone in coming up status
+		icon.addClass('grey');
+
+		// Append to list
+		$(".ui.list").append(newMilestone);
+
+		// Update progress
 	}
 </script>
 @endpush

--- a/resources/views/projects/milestones/index.blade.php
+++ b/resources/views/projects/milestones/index.blade.php
@@ -106,6 +106,16 @@
 		$(`.ui.form.milestones.${modalName}`).trigger('submit');
 	}
 
+	function updateDoneDate() {
+		console.log('Changed status');
+
+		if($(".status option:selected").val() != 1){
+			$(".doneDate").css("display", "none");
+			return false;
+		}
+		$(".doneDate").css("display", "block");
+	}
+
 	// Form validation
 	const milestoneFields = {
 		milestoneName: ["empty", "maxLength[30]"],
@@ -189,6 +199,7 @@
 					addMilestone(data);
 					addToProgress(data);
 				}
+				location.reload();
 			},
 			error: function (xhr, status) {
 				console.log(values);

--- a/resources/views/projects/milestones/index.blade.php
+++ b/resources/views/projects/milestones/index.blade.php
@@ -104,6 +104,7 @@
 		$form.find('.milestoneName').val(milestone.name);
 		let status = milestone.status === null ? 0 : milestone.status;
 		$form.find('.status').dropdown('set selected', status);
+		$form.find('.prevMilestone').dropdown('clear');
 		$form.find('.ui.calendar').calendar('set date', milestone.done_date);
 		$form.find('.prevMilestone').dropdown('set selected', milestone.previous_milestone_id);
 		$('#edit-milestone-modal').modal('show');

--- a/resources/views/projects/milestones/index.blade.php
+++ b/resources/views/projects/milestones/index.blade.php
@@ -11,9 +11,13 @@
 		</tr>
 	</thead>
 	<tbody id="milestoneList">
-		@foreach($project->milestones as $milestone)
-		<tr data-index="{{ $loop->iteration }}">
-			<td>{{ $loop->iteration }}</td>
+		@for($i = 1; $i <= count($project->milestones); $i++)
+		<tr data-index="{{ $i }}">
+			<td>{{ $i }}</td>
+			@php
+				$milestone = $i > 1 ?  $project->next_milestone($milestone->id) : $project->first_milestone();
+			@endphp
+			@if(isset($milestone))
 			<td class="name">{{ $milestone->name }}</td>
 			<td class="status">
 				@switch($milestone->status)
@@ -33,8 +37,9 @@
 			<td class="buttons">
 				<button data-id="{{ $milestone->id }}" class="ui button primary milestoneEditBtn">Edit</button>
 			</td>
+			@endif
 		</tr>
-		@endforeach
+		@endfor
 	</tbody>
 </table>
 
@@ -203,10 +208,8 @@
 				}
 				location.reload();
 			},
-			error: function (xhr, status) {
-				console.log(values);
-				console.error(status);
-				console.error(xhr);
+			error: function (data) {
+				console.log(data);
 				// TODO: Let's be more specific about this
 				alert(`Uh oh! Something went wrong and we couldn't ${isEdit ? "save": "create"} your milestone. Please try again later.`);
 			},


### PR DESCRIPTION
# Changes
- Project cards have current milestone
- When new/edit milestone, page is reloaded
- Modals are prevented from closing
- Merged @katiearriagam 's branch (milestones-ordered

## Pending
- Check following use cases:
1. When a user wants to add a new milestone at the beginning of the list, where prevMilestone = null but needs to rearrange old beginning.
2. When a user wants to add a new milestone at the end of the list.